### PR TITLE
fix issue with ini file icon and reboots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ domp4s
 extrascript
 dotimelapse
 .config.backup
+ukmon.ini
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/refreshTools.sh
+++ b/refreshTools.sh
@@ -56,6 +56,12 @@ else
         echo ""
         read -p "Press any key to continue"
     fi
+    if [ ! -f $here/ukmon.ini ] ; then 
+        echo  "# config data for this station" > $here/ukmon.ini
+        echo  "export LOCATION=NOTCONFIGURED" >> $here/ukmon.ini
+        echo  "export UKMONHELPER=3.8.65.98" >> $here/ukmon.ini
+        echo  "export UKMONKEY=~/.ssh/ukmon" >> $here/ukmon.ini
+    fi 
 fi
 if [ $(grep ukmonPost ~/source/RMS/.config | wc -l) -eq 0 ] ; then
     python -c 'import ukmonPostProc as pp ; pp.installUkmonFeed();'

--- a/refreshTools.sh
+++ b/refreshTools.sh
@@ -12,6 +12,13 @@ git stash
 git pull
 git stash apply
 
+if [ ! -f $here/ukmon.ini ] ; then
+    echo  "# config data for this station" > $here/ukmon.ini
+    echo  "export LOCATION=NOTCONFIGURED" >> $here/ukmon.ini
+    echo  "export UKMONHELPER=3.8.65.98" >> $here/ukmon.ini
+    echo  "export UKMONKEY=~/.ssh/ukmon" >> $here/ukmon.ini
+fi 
+
 if [ -f  $here/.firstrun ] ; then 
     if [[ "$LOCATION" != "NOTCONFIGURED"  && "$LOCATION" != "" ]] ; then
         if [ $(file $here/ukmon.ini | grep CRLF | wc -l) -ne 0 ] ; then
@@ -57,13 +64,6 @@ else
         read -p "Press any key to continue"
     fi
 fi
-
-if [ ! -f $here/ukmon.ini ] ; then
-    echo  "# config data for this station" > $here/ukmon.ini
-    echo  "export LOCATION=NOTCONFIGURED" >> $here/ukmon.ini
-    echo  "export UKMONHELPER=3.8.65.98" >> $here/ukmon.ini
-    echo  "export UKMONKEY=~/.ssh/ukmon" >> $here/ukmon.ini
-fi 
 
 if [ $(grep ukmonPost ~/source/RMS/.config | wc -l) -eq 0 ] ; then
     python -c 'import ukmonPostProc as pp ; pp.installUkmonFeed();'

--- a/refreshTools.sh
+++ b/refreshTools.sh
@@ -56,13 +56,15 @@ else
         echo ""
         read -p "Press any key to continue"
     fi
-    if [ ! -f $here/ukmon.ini ] ; then 
-        echo  "# config data for this station" > $here/ukmon.ini
-        echo  "export LOCATION=NOTCONFIGURED" >> $here/ukmon.ini
-        echo  "export UKMONHELPER=3.8.65.98" >> $here/ukmon.ini
-        echo  "export UKMONKEY=~/.ssh/ukmon" >> $here/ukmon.ini
-    fi 
 fi
+
+if [ ! -f $here/ukmon.ini ] ; then
+    echo  "# config data for this station" > $here/ukmon.ini
+    echo  "export LOCATION=NOTCONFIGURED" >> $here/ukmon.ini
+    echo  "export UKMONHELPER=3.8.65.98" >> $here/ukmon.ini
+    echo  "export UKMONKEY=~/.ssh/ukmon" >> $here/ukmon.ini
+fi 
+
 if [ $(grep ukmonPost ~/source/RMS/.config | wc -l) -eq 0 ] ; then
     python -c 'import ukmonPostProc as pp ; pp.installUkmonFeed();'
 fi 

--- a/ukmonPostProc.py
+++ b/ukmonPostProc.py
@@ -125,8 +125,8 @@ def rmsExternal(cap_dir, arch_dir, config):
 
     uploadToArchive.uploadToArchive(arch_dir, log)
 
-    os.remove(rebootlockfile)
-
+    # do not remote reboot lock file if running another script
+    # os.remove(rebootlockfile)
     try:
         with open(os.path.join(myloc, 'extrascript'),'r') as extraf:
             extrascript=extraf.readline().strip()


### PR DESCRIPTION
No ini file was created by the script but the desktop icon pointed to it. This caused problems using the icon to save / update the ini file. Resolved by creating a default ini file when the toolset is first installed. 

Resolved issue with reboot. The code removed the lock file before calling an external script. The external script immediately recreated it, but very occasionally, RMS would check at that exact moment. If the file was deleted but not yet recreated RMS would reboot the pi, causing further processing to fail. 