### PR TITLE
Some Support for docker and ubuntu

### DIFF
--- a/refreshTools.sh
+++ b/refreshTools.sh
@@ -43,10 +43,6 @@ if [ ! -f  ${UKMONKEY} ] ; then
     echo ""
     read -p "Press any key to continue"
 fi
-# add Desktop icons
-export PYTHONPATH=$here:~/source/RMS
-statid=$(grep ID $RMSCFG | awk -F" " '{print $2}')
-python -c "import ukmonInstaller as pp ; pp.addDesktopIcons('${here}','${statid}');"
 
 # if the station is configured, retrieve the AWS keys
 # and test connectivity. Also checks the ukmon.ini file is in unix format

--- a/refreshTools.sh
+++ b/refreshTools.sh
@@ -84,12 +84,12 @@ EOF
     python $here/sendToLive.py test test
     python $here/uploadToArchive.py test
     echo "if you did not see two success messages contact us for advice" 
-    read -p "Press any key to continue"
+    if [ "$DOCKER_RUNNING" != "true" ] ; then read -p "Press any key to continue" ; fi
     echo "done"
 else
     echo "Location missing - please update UKMON Config File using the desktop icon"
     sleep 5
-    read -p "Press any key to continue"
+    if [ "$DOCKER_RUNNING" != "true" ] ; then read -p "Press any key to continue" ; fi
     exit 1
 fi
 

--- a/ukmonInstaller.py
+++ b/ukmonInstaller.py
@@ -148,6 +148,19 @@ def createSystemdService(myloc, camid):
 
 
 def createUbuntuIcon(myloc, statid):
+    reflnk = os.path.expanduser('~/Desktop/refresh_UKMON_tools_{}.desktop'.format(statid))
+    os.remove(reflnk)
+    with open(reflnk, 'w') as outf:
+        outf.write('[Desktop Entry]\n')
+        outf.write('Name=refresh_UKMON_Tools_{}\n'.format(statid))
+        outf.write('Comment=Runs ukmon tools refresh\n')
+        outf.write('Exec={}\n'.format(os.path.join(myloc, 'refreshTools.sh')))
+        outf.write('Icon=\n')
+        outf.write('Terminal=true\n')
+        outf.write('Type=Application\n')
+    cmdstr = 'gio set {} metadata::trusted true'.format(reflnk)
+    call([cmdstr], shell=True)
+    os.chmod(reflnk, 0o744)
     return 
 
 

--- a/ukmonInstaller.py
+++ b/ukmonInstaller.py
@@ -8,6 +8,7 @@ import paramiko
 import json
 import tempfile
 import RMS.ConfigReader as cr
+from RMS.Misc import isRaspberryPi
 
 # Copyright (C) 2018-2023 Mark McIntyre
 
@@ -146,6 +147,10 @@ def createSystemdService(myloc, camid):
     return 
 
 
+def createUbuntuIcon(myloc, statid):
+    return 
+
+
 def addDesktopIcons(myloc, statid):
     """
     This function adds the desktop icons which are links to the ini file and refresh scripts
@@ -156,9 +161,12 @@ def addDesktopIcons(myloc, statid):
     cfglnk = os.path.expanduser('~/Desktop/UKMON_config_{}.txt'.format(statid))
     if not os.path.islink(cfglnk):
         os.symlink(os.path.join(myloc, 'ukmon.ini'), cfglnk)
-    reflnk = os.path.expanduser('~/Desktop/refresh_UKMON_tools_{}.sh'.format(statid))
-    if not os.path.islink(reflnk):
-        os.symlink(os.path.join(myloc, 'refreshTools.sh'), reflnk)
+    if isRaspberryPi is True:
+        reflnk = os.path.expanduser('~/Desktop/refresh_UKMON_tools_{}.sh'.format(statid))
+        if not os.path.islink(reflnk):
+            os.symlink(os.path.join(myloc, 'refreshTools.sh'), reflnk)
+    else:
+        createUbuntuIcon(myloc, statid)
     # remove bad links if present
     cfglnk = os.path.expanduser('~/Desktop/UKMON_config_XX0001.txt')
     if os.path.islink(cfglnk):

--- a/ukmonInstaller.py
+++ b/ukmonInstaller.py
@@ -148,8 +148,10 @@ def createSystemdService(myloc, camid):
 
 
 def createUbuntuIcon(myloc, statid):
+    reflnk = os.path.expanduser('~/Desktop/refresh_UKMON_tools_{}.sh'.format(statid))
+    if os.path.isfile(reflnk):
+        os.remove(reflnk)
     reflnk = os.path.expanduser('~/Desktop/refresh_UKMON_tools_{}.desktop'.format(statid))
-    os.remove(reflnk)
     with open(reflnk, 'w') as outf:
         outf.write('[Desktop Entry]\n')
         outf.write('Name=refresh_UKMON_Tools_{}\n'.format(statid))

--- a/ukmonInstaller.py
+++ b/ukmonInstaller.py
@@ -11,6 +11,7 @@ import RMS.ConfigReader as cr
 
 # Copyright (C) 2018-2023 Mark McIntyre
 
+
 def createDefaultIni(homedir, helperip=None):
     rmscfg = '~/source/RMS/.config'
     keyfile = '~/.ssh/ukmon'
@@ -158,6 +159,13 @@ def addDesktopIcons(myloc, statid):
     reflnk = os.path.expanduser('~/Desktop/refresh_UKMON_tools_{}.sh'.format(statid))
     if not os.path.islink(reflnk):
         os.symlink(os.path.join(myloc, 'refreshTools.sh'), reflnk)
+    # remove bad links if present
+    cfglnk = os.path.expanduser('~/Desktop/UKMON_config_XX0001.txt')
+    if os.path.islink(cfglnk):
+        os.unlink(cfglnk)
+    reflnk = os.path.expanduser('~/Desktop/refresh_UKMON_tools_XX0001.sh')
+    if os.path.islink(reflnk):
+        os.unlink(reflnk)
     return
 
 


### PR DESCRIPTION
* At the end of refreshTools, it waits for user input. This hangs in a docker container so I've put some protection round it.
* I've created a proper desktop icon for refreshTools, as the simple link approach doesn't work reliably on Ubuntu
* I've removed the bug that erroneously created XX0001 icons. 
